### PR TITLE
centered scroll bar

### DIFF
--- a/chrome/custom-youtube-speed/src/browser_action/browser_action.html
+++ b/chrome/custom-youtube-speed/src/browser_action/browser_action.html
@@ -62,7 +62,7 @@
 			</p>
 		</div>
 	</p>
-	<p>
+	<p style="align-items: center; display: flex;">
 		<span class="mno">0.1</span><input name="cys-speedRange" id="cys-speedRange" style="width: 80%;" type="range"
 			min="0.1" max=8 step="0.1" /><span class="mno">8.0</span>
 	</p>


### PR DESCRIPTION
Centering of the scroll bar:

So I noticed the side scrolling range input wasn't quite centered vertically between the numbers 0.1 and 8.0. 

Before: 
![image](https://user-images.githubusercontent.com/22485301/149798619-a9cbcdec-3ebf-4dc7-ab9a-4d65e6f443db.png)

After:
![image](https://user-images.githubusercontent.com/22485301/149798642-b258134e-9dc7-4934-85c5-6ba1e692659e.png)

A very minor fix but worth while to me at least. 